### PR TITLE
add dockerhub details

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,6 +52,15 @@ docker build -t=i3sa .
 
 Note: The Docker currently does not automatically pull this (private) repository. Please attach to the Docker and use your Gitlab credentials to manually pull the code.
 
+=== Pull docker image
+
+An image maintained by Eurobench can be automatically downloaded, without neeing to clone this code:
+
+[source, console]
+docker pull eurobenchtest/eb_hum_bench
+# if the name i3sa is to be maintained:
+docker tag eurobenchtest/eb_hum_bench i3sa:latest
+
 === Launch the docker image
 
 Assuming the tests/reemc_conf/ contains the robot data (in this case REEM-C), tests/test/input contains the input data, the PI output will be written to output:

--- a/README.adoc
+++ b/README.adoc
@@ -50,16 +50,17 @@ run_i3sa.py --conf tests/reemc_conf/robot.yaml --pos tests/input/2021_02_19/14/1
 [source]
 docker build -t=i3sa .
 
-Note: The Docker currently does not automatically pull this (private) repository. Please attach to the Docker and use your Gitlab credentials to manually pull the code.
+Note: The Docker currently does not automatically pull this (private) repository. Please attach to the Docker and use your credentials to manually pull the code.
 
 === Pull docker image
 
-An image maintained by Eurobench can be automatically downloaded, without neeing to clone this code:
+An image maintained by Eurobench can be automatically downloaded, without needing to clone this code.
+First visit the link:https://hub.docker.com/repository/docker/eurobenchtest/eb_hum_bench[Docker Hub page], and check the latest tag, which has to be used in the following command:
 
-[source, console]
-docker pull eurobenchtest/eb_hum_bench
+[source]
+docker pull eurobenchtest/eb_hum_bench:tag
 # if the name i3sa is to be maintained:
-docker tag eurobenchtest/eb_hum_bench i3sa:latest
+docker rename eurobenchtest/eb_hum_bench:tag i3sa:latest
 
 === Launch the docker image
 


### PR DESCRIPTION
A docker image is now available from Docker Hub.
Details provided on the Readme file